### PR TITLE
stats: add command to summarize tasks with --format json (with tests)

### DIFF
--- a/src/cli_todo/cli.py
+++ b/src/cli_todo/cli.py
@@ -29,6 +29,9 @@ def main(argv=None):
     p_search = sub.add_parser("search", help="Search tasks by keyword")
     p_search.add_argument("keyword", help="Keyword to search for")
 
+    p_stats = sub.add_parser("stats", help="Show totals and completion rate")
+    p_stats.add_argument("--format", choices=["text", "json"], default="text", help="Output format (default: text)")
+
     args = parser.parse_args(argv)
 
     if args.cmd == "add":
@@ -112,6 +115,20 @@ def main(argv=None):
             status = "✓" if t.completed else " "
             print(f"{t.id}. [{status}] {t.description}")
         return 0
+    
+    if args.cmd == "stats":
+        from .core import compute_stats
+        s = compute_stats()
+        if args.format == "json":
+            import json
+            print(json.dumps(s, indent=2))
+            return 0
+        print(f"Total: {s['total']}")
+        print(f"Active: {s['active']}")
+        print(f"Completed: {s['completed']}")
+        print(f"Completion rate: {s['completion_rate']}")
+        return 0
+
         
     if args.cmd == "clear":
         removed = clear_completed()

--- a/src/cli_todo/core.py
+++ b/src/cli_todo/core.py
@@ -84,6 +84,20 @@ def search_tasks(keyword: str):
     kw = keyword.lower()
     return [t for t in tasks if kw in t.description.lower()]
 
+def compute_stats():
+    """Return a dict with total, active, completed, completion_rate (0..1 float)."""
+    tasks = load_tasks()
+    total = len(tasks)
+    completed = sum(1 for t in tasks if t.completed)
+    active = total - completed
+    completion_rate = (completed / total) if total > 0 else 0.0
+    return {
+        "total": total,
+        "active": active,
+        "completed": completed,
+        "completion_rate": round(completion_rate, 3),
+    }
+
 def clear_completed():
     tasks = load_tasks()
     keep = [t for t in tasks if not t.completed]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,39 @@
+import os, sys, tempfile, subprocess
+from cli_todo import core
+
+def _run_cli(*args, env=None):
+    cmd = [sys.executable, "-m", "cli_todo.cli", *args]
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+def test_stats_text_and_json():
+    with tempfile.TemporaryDirectory() as tmp:
+        env = os.environ.copy()
+        env["CLI_TODO_DB_DIR"] = tmp
+
+        # No tasks -> totals 0
+        p = _run_cli("stats", env=env)
+        assert p.returncode == 0
+        assert "total: 0" in p.stdout.lower()
+
+        # Add two, complete one
+        core.add_task("Write tests")      # id 1
+        core.add_task("Fix bug")          # id 2
+        assert core.complete_task(1)
+
+        # Text stats
+        p = _run_cli("stats", env=env)
+        out = p.stdout.lower()
+        assert p.returncode == 0
+        assert "total: 2" in out
+        assert "active: 1" in out
+        assert "completed: 1" in out
+        # completion rate should be 0.5 (or 50%)
+        assert "0.5" in out or "50%" in out
+
+        # JSON stats
+        p = _run_cli("stats", "--format", "json", env=env)
+        assert p.returncode == 0
+        assert p.stdout.strip().startswith("{")
+        assert '"total": 2' in p.stdout
+        assert '"active": 1' in p.stdout
+        assert '"completed": 1' in p.stdout


### PR DESCRIPTION
## Summary
Adds `todo stats` to show totals and completion rate; supports `--format json` for automation.

## Issue
Fixes #11 

## Details
- Text format prints Total/Active/Completed/Completion rate
- JSON format returns {"total", "active", "completed", "completion_rate"}
- Handles empty dataset (0 tasks) gracefully
- Tests: tests/test_stats.py for text+JSON behavior

## Pre-checkin
- [x] Local tests pass
- [x] Scope minimal and targeted
- [x] Linked issue
