### PR TITLE
delete: add command to remove task by id (with tests)

### DIFF
--- a/src/cli_todo/cli.py
+++ b/src/cli_todo/cli.py
@@ -30,6 +30,9 @@ def main(argv=None):
     p_search = sub.add_parser("search", help="Search tasks by keyword")
     p_search.add_argument("keyword", help="Keyword to search for")
 
+    p_delete = sub.add_parser("delete", help="Delete a task by id")
+    p_delete.add_argument("id", type=int, help="Task id to delete")
+
     p_stats = sub.add_parser("stats", help="Show totals and completion rate")
     p_stats.add_argument("--format", choices=["text", "json"], default="text", help="Output format (default: text)")
 
@@ -120,6 +123,16 @@ def main(argv=None):
             print(f"{t.id}. [{status}] {t.description}")
         return 0
     
+    if args.cmd == "delete":
+        from .core import delete_task
+        ok = delete_task(args.id)
+        if ok:
+            print(f"[deleted] {args.id}")
+            return 0
+        else:
+            print(f"Error: no task with id {args.id} found.", file=sys.stderr)
+            return 1
+
     if args.cmd == "stats":
         from .core import compute_stats
         s = compute_stats()

--- a/src/cli_todo/core.py
+++ b/src/cli_todo/core.py
@@ -100,6 +100,15 @@ def search_tasks(keyword: str):
     kw = keyword.lower()
     return [t for t in tasks if kw in t.description.lower()]
 
+def delete_task(task_id: int) -> bool:
+    """Delete a task by id. Return True if deleted, else False."""
+    tasks = load_tasks()
+    new_tasks = [t for t in tasks if t.id != task_id]
+    if len(new_tasks) == len(tasks):
+        return False
+    save_tasks(new_tasks)
+    return True
+
 def compute_stats():
     """Return a dict with total, active, completed, completion_rate (0..1 float)."""
     tasks = load_tasks()

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,25 @@
+import os, sys, tempfile, subprocess
+from cli_todo import core
+
+def _run_cli(*args, env=None):
+    cmd = [sys.executable, "-m", "cli_todo.cli", *args]
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+def test_delete_happy_and_error_paths():
+    with tempfile.TemporaryDirectory() as tmp:
+        env = os.environ.copy()
+        env["CLI_TODO_DB_DIR"] = tmp
+
+        core.add_task("Write docs")   # id 1
+        core.add_task("Fix bug")      # id 2
+
+        p = _run_cli("delete", "1", env=env)
+        assert p.returncode == 0
+
+        lp = _run_cli("list", env=env);      assert "Write docs" not in lp.stdout
+        lj = _run_cli("list", "--format", "json", env=env)
+        assert '"Write docs"' not in lj.stdout
+
+        p = _run_cli("delete", "999", env=env)
+        assert p.returncode != 0
+        assert (p.stderr or p.stdout).lower().find("no task") != -1


### PR DESCRIPTION
## Summary
Adds `todo delete <id>` to remove a task by id.

## Issue
Fixes #15

## Details
- Success: prints "[deleted] <id>" and exits 0
- Error: invalid id -> prints error to stderr, exit 1
- Tests: tests/test_delete.py covers happy and error paths

## Pre-checkin
- [x] Local tests pass
- [x] Scope minimal and targeted
- [x] Linked issue
